### PR TITLE
Fix confusing comments in User model

### DIFF
--- a/api/models/users.js
+++ b/api/models/users.js
@@ -67,7 +67,7 @@ const getByEmail = async(email) => {
     throw new Error(`"${email}" is not a valid email address`)
   }
 
-  // Save
+  // Query
   const params = {
     TableName: process.env.db,
     KeyConditionExpression: 'hk = :hk',
@@ -96,7 +96,7 @@ const getById = async(id) => {
     throw new Error(`"id" is required`)
   }
 
-  // Save
+  // Query
   const params = {
     TableName: process.env.db,
     IndexName: process.env.dbIndex1,


### PR DESCRIPTION
The comments above the dynamodb params in `getByEmail` and `getById` functions were indicating a save instead of a query, probably due to a copy/paste from the `register` function.